### PR TITLE
fix: Fix KeepLetterCase setting display exception

### DIFF
--- a/internal/settings/appearance/appearance.go
+++ b/internal/settings/appearance/appearance.go
@@ -105,6 +105,7 @@ func pageAppearance(c *gin.Context) {
 			"OptionHideSettingsButton":  options.HideSettingsButton,
 			"OptionHideHelpButton":      options.HideHelpButton,
 			"OptionEnableEncryptedLink": options.EnableEncryptedLink,
+			"OptionKeepLetterCase":      options.KeepLetterCase,
 			"OptionIconModeDefault":     IconModeDefault,
 			"OptionIconModeFilling":     IconModeFilling,
 		},


### PR DESCRIPTION
Fixed `KeepLetterCase` setting item display exception in appearance settings.