### PR TITLE
fix: Fix an encrypted link that may not be decoded

### DIFF
--- a/internal/data/serializer.go
+++ b/internal/data/serializer.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -43,6 +44,16 @@ func GenerateRandomString(size int) string {
 	return hex.EncodeToString(id)[:size]
 }
 
-func Base64Encode(input string) string {
-	return base64.StdEncoding.EncodeToString([]byte(input))
+func Base64EncodeUrl(input string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(input))
+	return url.QueryEscape(encoded)
+}
+
+func Base64DecodeUrl(input string) ([]byte, error) {
+	unescaped, err := url.QueryUnescape(input)
+	if err != nil {
+		return []byte{}, err
+	}
+	return base64.StdEncoding.DecodeString(unescaped)
+
 }

--- a/internal/pages/home/application.go
+++ b/internal/pages/home/application.go
@@ -41,10 +41,10 @@ func GenerateApplicationsTemplate(filter string) template.HTML {
 		// 则使用服务端 Location 方式打开链接
 		templateURL := ""
 		if strings.HasPrefix(app.URL, "chrome-extension://") {
-			templateURL = "/redir/" + FlareData.Base64Encode(app.URL)
+			templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(app.URL)
 		} else {
 			if options.EnableEncryptedLink {
-				templateURL = "/redir/" + FlareData.Base64Encode(app.URL)
+				templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(app.URL)
 			} else {
 				templateURL = app.URL
 			}

--- a/internal/pages/home/bookmark.go
+++ b/internal/pages/home/bookmark.go
@@ -1,7 +1,6 @@
 package home
 
 import (
-	"encoding/base64"
 	"html/template"
 	"strings"
 
@@ -50,10 +49,10 @@ func renderBookmarksWithoutCategories(bookmarks *[]FlareModel.Bookmark, OpenBook
 		// 则使用服务端 Location 方式打开链接
 		templateURL := ""
 		if strings.HasPrefix(bookmark.URL, "chrome-extension://") {
-			templateURL = "/redir/" + base64.StdEncoding.EncodeToString([]byte(bookmark.URL))
+			templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(bookmark.URL)
 		} else {
 			if EnableEncryptedLink {
-				templateURL = "/redir/" + FlareData.Base64Encode(bookmark.URL)
+				templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(bookmark.URL)
 			} else {
 				templateURL = bookmark.URL
 			}
@@ -91,10 +90,10 @@ func renderBookmarksWithCategories(bookmarks *[]FlareModel.Bookmark, category *F
 		// 则使用服务端 Location 方式打开链接
 		templateURL := ""
 		if strings.HasPrefix(bookmark.URL, "chrome-extension://") {
-			templateURL = "/redir/" + base64.StdEncoding.EncodeToString([]byte(bookmark.URL))
+			templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(bookmark.URL)
 		} else {
 			if EnableEncryptedLink {
-				templateURL = "/redir/" + FlareData.Base64Encode(bookmark.URL)
+				templateURL = "/redir/url?go=" + FlareData.Base64EncodeUrl(bookmark.URL)
 			} else {
 				templateURL = bookmark.URL
 			}

--- a/internal/redir/redir.go
+++ b/internal/redir/redir.go
@@ -1,7 +1,6 @@
 package redir
 
 import (
-	"encoding/base64"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -23,8 +22,14 @@ func RegisterRouting(router *gin.Engine) {
 	})
 
 	router.GET(FlareState.MiscPages.RedirHelper.Path, func(c *gin.Context) {
-		encoded := c.Param("url")
-		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		encoded := c.Query("go")
+		if len(encoded) < 1 {
+			c.Data(http.StatusBadRequest, "text/html; charset=utf-8", internalError)
+			c.Abort()
+			return
+		}
+
+		decoded, err := FlareData.Base64DecodeUrl(encoded)
 		if err != nil {
 			c.Data(http.StatusBadRequest, "text/html; charset=utf-8", internalError)
 			c.Abort()

--- a/internal/state/router.go
+++ b/internal/state/router.go
@@ -119,7 +119,7 @@ func getMiscPages() FlareModel.RouteMaps {
 		},
 		RedirHelper: FlareModel.API{
 			Name: "RedirHelper",
-			Path: "/redir/:url",
+			Path: "/redir/url",
 		},
 
 		Login: FlareModel.API{


### PR DESCRIPTION
Resolve: soulteary/docker-flare#119

---

### 问题原因

在启用加密链接功能后，程序会对网址进行 Base64 编码，然后放置在路径段 `/redir/{encoded}` 中。但是 Base64 编码的结果本身是会产生 `+` 和 `/` 字符的，故当结果中出现 `/` 时，会直接导致路由 `/redir/:url` 无法识别而**响应 404** (*注：因为是无法识别该路由，所以也无法加载到程序本身设定好的"找不到匹配的跳转地址..."页面*)，如上面提及的 issue。

### 解决思路

使用 `net/url` 标准库转义 Base64 编码的字符串。

### 修改内容

1. 在 `data.Base64Encode` 方法中添加转义代码并且将方法重命名为 `data.Base64EncodeUrl`，同时添加对应解码的方法 `data.Base64DecodeUrl`。
2. 不再将加密内容直接放置在路径段中，而是作为查询参数传递。即修改路由 `/redir/:url` 为 `/redir/url`，并在路由注册处理程序中使用 `(gin.Context).Query("go")` 读取 `go` 查询参数。
