### PR TITLE
feat: Support for dynamic URL parameters

### DIFF
--- a/internal/pages/home/application.go
+++ b/internal/pages/home/application.go
@@ -13,19 +13,25 @@ import (
 func GenerateApplicationsTemplate(filter string) template.HTML {
 	options := FlareData.GetAllSettingsOptions()
 	appsData := FlareData.LoadFavoriteBookmarks()
+	tpl := ""
+
+	var parseApps []FlareModel.Bookmark
+	for _, app := range appsData.Items {
+		app.URL = FlareState.ParseDynamicUrl(app.URL)
+		parseApps = append(parseApps, app)
+	}
 
 	var apps []FlareModel.Bookmark
-	tpl := ""
 
 	if filter != "" {
 		filterLower := strings.ToLower(filter)
-		for _, bookmark := range appsData.Items {
+		for _, bookmark := range parseApps {
 			if strings.Contains(strings.ToLower(bookmark.Name), filterLower) || strings.Contains(strings.ToLower(bookmark.URL), filterLower) || strings.Contains(strings.ToLower(bookmark.Desc), filterLower) {
 				apps = append(apps, bookmark)
 			}
 		}
 	} else {
-		apps = appsData.Items
+		apps = parseApps
 	}
 
 	for _, app := range apps {

--- a/internal/pages/home/bookmark.go
+++ b/internal/pages/home/bookmark.go
@@ -15,18 +15,24 @@ func GenerateBookmarkTemplate(filter string) template.HTML {
 	bookmarksData := FlareData.LoadNormalBookmarks()
 	tpl := ""
 
+	var parseBookmarks []FlareModel.Bookmark
+	for _, bookmark := range bookmarksData.Items {
+		bookmark.URL = FlareState.ParseDynamicUrl(bookmark.URL)
+		parseBookmarks = append(parseBookmarks, bookmark)
+	}
+
 	var bookmarks []FlareModel.Bookmark
 
 	if filter != "" {
 		filterLower := strings.ToLower(filter)
 
-		for _, bookmark := range bookmarksData.Items {
+		for _, bookmark := range parseBookmarks {
 			if strings.Contains(strings.ToLower(bookmark.Name), filterLower) || strings.Contains(strings.ToLower(bookmark.URL), filterLower) {
 				bookmarks = append(bookmarks, bookmark)
 			}
 		}
 	} else {
-		bookmarks = bookmarksData.Items
+		bookmarks = parseBookmarks
 	}
 
 	if len(bookmarksData.Categories) > 0 {

--- a/internal/pages/home/home.go
+++ b/internal/pages/home/home.go
@@ -226,6 +226,7 @@ func getGreeting(greeting string) string {
 
 func pageBookmark(c *gin.Context) {
 	options := FlareData.GetAllSettingsOptions()
+	FlareState.ParseRequestURL(c.Request)
 
 	c.HTML(
 		http.StatusOK,
@@ -257,6 +258,7 @@ func pageBookmark(c *gin.Context) {
 
 func pageApplication(c *gin.Context) {
 	options := FlareData.GetAllSettingsOptions()
+	FlareState.ParseRequestURL(c.Request)
 
 	c.HTML(
 		http.StatusOK,
@@ -287,6 +289,7 @@ func pageApplication(c *gin.Context) {
 
 func render(c *gin.Context, filter string) {
 	options := FlareData.GetAllSettingsOptions()
+	FlareState.ParseRequestURL(c.Request)
 
 	hasKeyword := false
 	searchKeyword := ""

--- a/internal/state/url.go
+++ b/internal/state/url.go
@@ -1,0 +1,62 @@
+package state
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type _Dynamic_URL struct {
+	Host     string
+	Hostname string
+	Href     string
+	Origin   string
+	Pathname string
+	Port     string
+	Protocol string
+}
+
+var RequestURL _Dynamic_URL
+
+func getPort(host string, defaultPort string) (hostname string, port string) {
+	hostname = host
+	port = defaultPort
+	reg, _ := regexp.Compile(`([\w+\.-]+):(\d+)$`)
+	portMatch := reg.FindStringSubmatch(host)
+	if portMatch != nil {
+		hostname = portMatch[1]
+		port = portMatch[2]
+	}
+	return
+}
+
+func ParseRequestURL(r *http.Request) {
+	scheme := "http:"
+	defaultPort := "80"
+	if r.TLS != nil {
+		scheme = "https:"
+		defaultPort = "443"
+	}
+	host := r.Host
+	hostname, port := getPort(host, defaultPort)
+
+	RequestURL.Host = host
+	RequestURL.Hostname = hostname
+	RequestURL.Href = strings.Join([]string{scheme, "//", host, r.RequestURI}, "")
+	RequestURL.Origin = strings.Join([]string{scheme, "//", host}, "")
+	RequestURL.Pathname = r.URL.Path
+	RequestURL.Port = port
+	RequestURL.Protocol = scheme
+}
+
+func ParseDynamicUrl(url string) string {
+	result := url
+	result = strings.ReplaceAll(result, "{host}", RequestURL.Host)
+	result = strings.ReplaceAll(result, "{hostname}", RequestURL.Hostname)
+	result = strings.ReplaceAll(result, "{href}", RequestURL.Href)
+	result = strings.ReplaceAll(result, "{origin}", RequestURL.Origin)
+	result = strings.ReplaceAll(result, "{pathname}", RequestURL.Pathname)
+	result = strings.ReplaceAll(result, "{port}", RequestURL.Port)
+	result = strings.ReplaceAll(result, "{protocol}", RequestURL.Protocol)
+	return result
+}


### PR DESCRIPTION
- Resolve: soulteary/docker-flare#129
- Resolve: soulteary/docker-flare#136

---

### 实现功能

支持在配置书签网址时使用动态的 URL 参数，以便允许以不同 IP 或域名加载 flare 服务时动态地提供所需书签网址，从而实现上述 issues 中提及的需求。

### 解决思路

从接收到的网络请求中解析出对应的动态参数，其中参数名称及其值内容参考 JavaScript 中的 [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) 接口。然后可以在书签的网址中使用 `{parameter}` 形式，当网页加载时会自动替换对应参数值至网址中。

### 参数及示例

假设 flare 首页地址为 `https://192.168.0.1:5005/`，以下各参数对应的解析结果：

| 参数名 | 解析结果 |
| --- | --- |
| `host` | `192.168.0.1:5005` |
| `hostname` | `192.168.0.1` |
| `href` | `https://192.168.0.1:5005/` |
| `origin` | `https://192.168.0.1:5005` |
| `pathname` | `/` |
| `port` | `5005` |
| `protocol` | `https:` |

**示例:** 假设书签网址配置为 `https://{hostname}:8888/test`，则在该首页中显示为 `https://192.168.0.1:8888/test`。

### 修改内容

- 新增 `internal/state/url.go` 文件，内部实现解析网络请求以及替换动态参数的方法。
- 在 `internal/pages/home/home.go` 文件中解析网络请求。
- 在 `internal/pages/home/application.go` 和 `internal/pages/home/bookmark.go` 中替换书签网址中的动态参数。
