### PR TITLE
Fix the interaction of login status when multiple flare in the same domain

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +23,7 @@ func RequestHandle(router *gin.Engine) {
 	// TODO: 剥离逻辑
 	// TODO：替换密钥为用户相关数据
 	store := cookie.NewStore([]byte("secret"))
-	router.Use(sessions.Sessions("flare", store))
+	router.Use(sessions.Sessions("flare_"+strconv.Itoa(FlareState.AppFlags.Port), store))
 
 	// 非离线模式注册路由
 	if !FlareState.AppFlags.DisableLoginMode {


### PR DESCRIPTION
### 问题

当在同一域名**不同端口**下搭建多个 flare 时，所有的 flare 中的用户登录状态均会相互影响(*即使用户名是不相同的*)。

### 解决方法

在 session 的键值中包含各自项目端口号信息。
