### PR TITLE
fix(envfile_test): Fix unit test error in Windows

### DIFF
--- a/cmd/envfile_test.go
+++ b/cmd/envfile_test.go
@@ -19,7 +19,9 @@ func TestCheckDotEnvFileExist(t *testing.T) {
 
 	// test .env exist
 	f, _ := os.Create(envPath)
-	defer os.Remove(f.Name())
+	filename := f.Name()
+	defer os.Remove(filename)
+	defer f.Close()
 	assert.Equal(t, FlareCMD.CheckDotEnvFileExist(envPath), true)
 }
 
@@ -65,6 +67,7 @@ func TestParseEnvFile_ParseErr(t *testing.T) {
 	// test .env auto correct
 	f, _ := os.Create(envPath)
 	defer os.Remove(envPath)
+	defer f.Close()
 	f.Write([]byte("FLARE_PORT=true\nFLARE_USER=\nFLARE_PASS=\nFLARE_GUIDE=1111"))
 	flags := FlareCMD.ParseEnvFile(envParsed)
 	assert.Equal(t, flags, envParsed)
@@ -85,6 +88,7 @@ func TestParseEnvFile_ParseOverwrite(t *testing.T) {
 	// test .env auto correct
 	f, _ := os.Create(envPath)
 	defer os.Remove(envPath)
+	defer f.Close()
 	f.Write([]byte("FLARE_PORT=2345\nFLARE_USER=\nFLARE_PASS=\nFLARE_GUIDE=false"))
 	flags := FlareCMD.ParseEnvFile(envParsed)
 
@@ -109,6 +113,7 @@ func TestParseEnvFile_PortError(t *testing.T) {
 	// test .env auto correct
 	f, _ := os.Create(envPath)
 	defer os.Remove(envPath)
+	defer f.Close()
 	f.Write([]byte("FLARE_PORT=9999999\nFLARE_USER=\nFLARE_PASS=\nFLARE_GUIDE=false"))
 	flags := FlareCMD.ParseEnvFile(envParsed)
 
@@ -133,6 +138,7 @@ func TestParseEnvFile_User(t *testing.T) {
 	// test .env auto correct
 	f, _ := os.Create(envPath)
 	defer os.Remove(envPath)
+	defer f.Close()
 	f.Write([]byte("FLARE_PORT=5005\nFLARE_USER=flare\nFLARE_PASS=\n"))
 	flags := FlareCMD.ParseEnvFile(envParsed)
 


### PR DESCRIPTION
*该问题仅存在于 Windows 系统中。*

### 问题现象

在 Windows 系统下运行 `go test` 进行单元测试时无法通过，但在 Linux 系统下则正常。

调试后发现 `os.Remove(envPath)` 等方法在 Windows 中并没有删除文件，而是报错：

```
The process cannot access the file because it is being used by another process.
```

从而导致某些依赖于不存在 `.env` 文件的单元测试无法通过。

### 问题原因

Windows 系统不允许直接删除已打开的文件。

### 解决方法

在 `envfile_test` 中删除 `.env` 文件前关闭文件。

测试在进行该处理之后在，于 Windows 和 Liunx 下的单元测试均可正常通过了。