### PR TITLE
fix: 修复CSRF导致跳转失败问题

### DIFF
--- a/internal/pages/home/application.go
+++ b/internal/pages/home/application.go
@@ -72,7 +72,7 @@ func GenerateApplicationsTemplate(filter string) template.HTML {
 		if options.OpenAppNewTab {
 			tpl = tpl + `
 			<div class="app-container" data-id="` + app.Icon + `">
-			<a target="_blank" rel="noopener" href="` + templateURL + `" class="app-item" title="` + app.Name + `">
+			<a target="_blank" rel="noopener noreferrer" href="` + templateURL + `" class="app-item" title="` + app.Name + `">
 			  <div class="app-icon">` + templateIcon + `</div>
 			  <div class="app-text">
 				<p class="app-title">` + app.Name + `</p>
@@ -84,7 +84,7 @@ func GenerateApplicationsTemplate(filter string) template.HTML {
 		} else {
 			tpl = tpl + `
 			<div class="app-container" data-id="` + app.Icon + `">
-			<a rel="noopener" href="` + templateURL + `" class="app-item" title="` + app.Name + `">
+			<a rel="noopener noreferrer" href="` + templateURL + `" class="app-item" title="` + app.Name + `">
 			  <div class="app-icon">` + templateIcon + `</div>
 			  <div class="app-text">
 				<p class="app-title">` + app.Name + `</p>


### PR DESCRIPTION
以下代码只能保证新页面不访问原始跳转页面，依然会携带上referer请求头。

这会导致部分应用会访问失败（参考qBitterrent-nox）,在开启CSRF的情况下，qBittorrent。

参考issue： #62 

```html
<a target="_blank" rel="noopener" href="` + templateURL + `" class="app-item" title="` + app.Name + `">
  <div class="app-icon">` + templateIcon + `</div>
  <div class="app-text">
    <p class="app-title">` + app.Name + `</p>
    <p class="app-desc">` + desc + `</p>
  </div>
</a>
```
